### PR TITLE
Fixed typo in markers.md

### DIFF
--- a/components/markers.md
+++ b/components/markers.md
@@ -20,7 +20,7 @@ React JS Implementation Live Video : [CodeSandbox](https://codesandbox.io/p/sand
   ```
 - **React js**
   ```js
-  markerObject = mapplsClassObject.marker({
+  markerObject = mapplsClassObject.Marker({
   map:  mapObject,
   position:{lat:28.5512908, lng:77.26809282},
   });


### PR DESCRIPTION
This pull request corrects a typo in the Maps API documentation for adding markers using React. The current documentation incorrectly refers to the method as "marker," while the actual method is named "Marker." It can be a time waster because a lot of people copy paste the code from docs.